### PR TITLE
Fix: [i18n] The string "Please enter a comment" in editorial-comments is not displayed translated

### DIFF
--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -215,6 +215,8 @@ if (! class_exists('PP_Editorial_Comments')) {
                 ]
             );
 
+            wp_set_script_translations( 'publishpress-editorial-comments', 'publishpress' );
+
             $thread_comments = (int)get_option('thread_comments'); ?>
             <script type="text/javascript">
                 var pp_thread_comments = <?php echo ($thread_comments) ? esc_html__($thread_comments) : 0; ?>;

--- a/modules/editorial-comments/lib/editorial-comments.js
+++ b/modules/editorial-comments/lib/editorial-comments.js
@@ -200,7 +200,7 @@ editorialCommentReply = {
         // Validation: check to see if comment entered
         post.content = jQuery.trim(jQuery('#pp-replycontent').val());
         if (!post.content) {
-            jQuery('#pp-replyrow .error').text('Please enter a comment').show();
+            jQuery('#pp-replyrow .error').text(wp.i18n.__('Please enter a comment', 'publishpress')).show();
             return;
         }
 
@@ -368,7 +368,7 @@ editorialCommentEdit = {
         // Validation: check to see if comment entered
         post.content = this.$.trim(this.$('#pp-editcontent').val());
         if (!post.content) {
-            var $errorLine = this.$('<div class="pp-error">').text('Please enter a comment');
+            var $errorLine = this.$('<div class="pp-error">').text(wp.i18n.__('Please enter a comment', 'publishpress'));
             this.$('#pp-editcontainer').append($errorLine);
             return;
         }


### PR DESCRIPTION
Fix: [i18n] The string "Please enter a comment" in editorial-comments is not displayed translated