### PR TITLE
update/#1744-Make-default-headings-sortable-in-Content-Overview 

### DIFF
--- a/modules/content-overview/content-overview.php
+++ b/modules/content-overview/content-overview.php
@@ -2564,6 +2564,9 @@ class PP_Content_Overview extends PP_Module
             'post_title',
             'post_date',
             'post_modified',
+            'post_type',
+            'post_status',
+            'post_author',
         ];
 
         return apply_filters('publishpress_content_overview_sortable_columns', $sortableColumns);


### PR DESCRIPTION
Make default headings sortable in Content Overview fix #1744