### PR TITLE
update/#1777-Prevent-Content-Board-posts-from-been-moved-to-status-user-doesn't-have-capability-to-create-post-in

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -871,6 +871,16 @@ if (!class_exists('PP_Module')) {
 
         public function getUserAuthorizedPostStatusOptions($postType)
         {
+            global $pp_post_type_status_options;
+
+            if (!is_array($pp_post_type_status_options)) {
+                $pp_post_type_status_options = [];
+            }
+
+            if (isset($pp_post_type_status_options[$postType])) {
+                return $pp_post_type_status_options[$postType];
+            }
+
             $postStatuses = $this->getPostStatusOptions();
 
             foreach ($postStatuses as $index => $status) {
@@ -882,6 +892,8 @@ if (!class_exists('PP_Module')) {
                     }
                 }
             }
+
+            $pp_post_type_status_options[$postType] = $postStatuses;
 
             return $postStatuses;
         }

--- a/modules/content-board/content-board.php
+++ b/modules/content-board/content-board.php
@@ -1029,6 +1029,17 @@ class PP_Content_Board extends PP_Module
                         $result[$status][] = $post;
                         return $result;
                     }, []);
+
+                $allowed_post_statuses = [];
+                foreach ((array)$postType as $single_post_type) {
+                    $allowed_post_statuses = array_merge($allowed_post_statuses, array_column( $this->getUserAuthorizedPostStatusOptions($single_post_type), 'value'));
+                }
+                if (in_array('publish', $allowed_post_statuses)) {
+                    $allowed_post_statuses[] = 'future';
+                    $allowed_post_statuses[] = 'private';
+                }
+                $allowed_post_statuses = array_unique($allowed_post_statuses);
+
                 ?>
                 <div class="statuses-contents">
                 <?php 
@@ -1037,6 +1048,14 @@ class PP_Content_Board extends PP_Module
                 foreach ($post_statuses as $post_status_object) :
                     if (!empty($post_status_object->alternate)) {
                         continue;
+                    }
+
+                    if (in_array($post_status_object->slug, $allowed_post_statuses)) {
+                        $board_class = 'can_move_to';
+                        $empty_card_message = esc_html__("Move posts here to change their status", "publishpress");
+                    } else {
+                        $board_class = 'can_not_move_to';
+                        $empty_card_message = esc_html__("You do not have permission to move post to this status", "publishpress");
                     }
 
                     $post_status_options = $this->get_post_status_options($post_status_object->slug); 
@@ -1103,11 +1122,11 @@ class PP_Content_Board extends PP_Module
                         </div>
                     </div>';
                     $statuses_content_markup .= '<div class="status-content board-main-content status-'. esc_attr($post_status_object->slug). '" data-slug="'. esc_attr($post_status_object->slug). '" data-counts="0">
-                        <div class="board-content">';
+                        <div class="board-content '. $board_class .'">';
                         // show empty card placeholder
                         $statuses_content_markup .= '
                                     <div class="content-item empty-card sortable-placeholder">
-                                        <div class="card-message-wrapper"><div class="drag-message"><p>'. esc_html__("Move posts here to change their status", "publishpress") .'</p></div> <div class="drag-permission-message">'. esc_html__("Only editable posts will be moveable.", "publishpress") .'</div> </div>
+                                        <div class="card-message-wrapper"><div class="drag-message"><p>'. $empty_card_message .'</p></div> <div class="drag-permission-message">'. esc_html__("Only editable posts will be moveable.", "publishpress") .'</div> </div>
                                     </div>';
                         $statuses_content_markup .= '</div>
                     </div>';
@@ -1130,7 +1149,7 @@ class PP_Content_Board extends PP_Module
                         </div>';
 
                         $statuses_content_markup .= '<div class="status-content board-main-content status-'. esc_attr($post_status_object->slug) .'" data-slug="'. esc_attr($post_status_object->slug) .'" data-counts="'. esc_attr(count($status_posts)) .'">
-                            <div class="board-content">';
+                            <div class="board-content '. $board_class .'">';
                             foreach ($status_posts as $status_post) :
 
                                 $post_type_object = get_post_type_object($status_post->post_type);
@@ -1249,7 +1268,7 @@ class PP_Content_Board extends PP_Module
                                 // show empty card placeholder
                                 $statuses_content_markup .= '
                                             <div class="content-item empty-card sortable-placeholder" style="display: none;">
-                                                <div class="card-message-wrapper"><div class="drag-message"><p>'. esc_html__("Move posts here to change their status", "publishpress") .'</p></div> <div class="drag-permission-message">'. esc_html__("Only editable posts will be moveable.", "publishpress") .'</div> </div>
+                                                <div class="card-message-wrapper"><div class="drag-message"><p>'. $empty_card_message .'</p></div> <div class="drag-permission-message">'. esc_html__("Only editable posts will be moveable.", "publishpress") .'</div> </div>
                                             </div>';
                             $statuses_content_markup .= '</div>
                             </div>';

--- a/modules/content-board/lib/content-board.js
+++ b/modules/content-board/lib/content-board.js
@@ -32,9 +32,9 @@ jQuery(document).ready(function ($) {
         });
     }
 
-    if ($('.content-board-table-wrap .board-content .content-item'.length > 0)) {
+    if ($('.content-board-table-wrap .board-content.can_move_to .content-item'.length > 0)) {
         // make content dragable
-        sortedPostCardsList($(".content-board-table-wrap .board-content"));
+        sortedPostCardsList($(".content-board-table-wrap .board-content.can_move_to"));
         // update empty card height
         var card_selector = $('.content-board-table-wrap .board-content .content-item:not(.empty-card)');
         var card_height = card_selector.height();
@@ -442,7 +442,7 @@ jQuery(document).ready(function ($) {
     function sortedPostCardsList(selector) {
     
         selector.sortable({
-            connectWith: ".content-board-table-wrap .board-content",
+            connectWith: ".content-board-table-wrap .board-content.can_move_to",
             items: "> .content-item:not(.no-drag)",
             placeholder: "sortable-placeholder",
             receive: function (event, ui) {

--- a/modules/content-board/library/content-board-methods.php
+++ b/modules/content-board/library/content-board-methods.php
@@ -52,9 +52,17 @@ if (! class_exists('PP_Board_Methods')) {
                 if (!is_object($post_data) || !isset($post_data->post_type)) {
                     $response['content'] = esc_html__('Error fetching post data.', 'publishpress');
                 } else {
+                    $user_post_status = array_column( $this->getUserAuthorizedPostStatusOptions($post_data->post_type), 'value');
+                    if (in_array('publish', $user_post_status)) {
+                        $user_post_status[] = 'future';
+                        $user_post_status[] = 'private';
+                    }
+
                     $post_type_object = get_post_type_object($post_data->post_type);
                     if (empty($post_type_object->cap->edit_posts) || !current_user_can($post_type_object->cap->edit_posts)) {
                         $response['content'] = esc_html__('You do not have permission to edit selected post.', 'publishpress');
+                    } elseif (!in_array($post_status, $user_post_status)) {
+                        $response['content'] = esc_html__('You do not have permission to move post to selected post status.', 'publishpress');
                     } else {
                         $post_args = [
                             'ID' => $post_id,


### PR DESCRIPTION
Prevent Content Board posts from been moved to status user doesn't have capability to create post in fix #1777