### PR TITLE
update/#1803-Show-only-Taxonomies-attached-to-selected-Post-Types-in-Filter 

### DIFF
--- a/common/php/class-module.php
+++ b/common/php/class-module.php
@@ -968,6 +968,33 @@ if (!class_exists('PP_Module')) {
         }
 
         /**
+         * Retrieve post types taxonomies
+         *
+         * @param array $post_types
+         *
+         * @return array
+         */
+        public function get_post_types_taxonomies($post_types)
+        {
+            $taxonomies = array_map(
+                function ( $post_type ) {
+                    return get_object_taxonomies( $post_type, 'objects' );
+                },
+                $post_types
+            );
+            
+            // Make sure there's no duplicate
+            $taxonomies = call_user_func_array( 'array_merge', $taxonomies );
+
+            // Keep only those where show_ui is not empty.
+            $taxonomies = array_filter( $taxonomies, function( $taxonomy ) {
+                return ! empty( $taxonomy->show_ui );
+            });
+            
+            return $taxonomies;
+        }
+
+        /**
          *
          * @param string $param The parameter to look for in $_GET
          *

--- a/modules/calendar/calendar.php
+++ b/modules/calendar/calendar.php
@@ -969,7 +969,7 @@ if (! class_exists('PP_Calendar')) {
             }
     
             // add taxononomies
-            $taxonomies = $this->get_all_taxonomies();
+            $taxonomies = $this->get_post_types_taxonomies($this->get_selected_post_types());
             $all_taxonomies = [];
             foreach ($taxonomies as $taxonomy) {
                 if (in_array($taxonomy->name, ['post_status', 'post_status_core_wp_pp', 'post_visibility_pp', 'pp_revision_status'])) {

--- a/modules/content-board/content-board.php
+++ b/modules/content-board/content-board.php
@@ -679,7 +679,7 @@ class PP_Content_Board extends PP_Module
         }
 
         // add taxononomies
-        $taxonomies = $this->get_all_taxonomies();
+        $taxonomies = $this->get_post_types_taxonomies($this->get_selected_post_types());
         $all_taxonomies = [];
         foreach ($taxonomies as $taxonomy) {
             if (in_array($taxonomy->name, ['post_status', 'post_status_core_wp_pp', 'post_visibility_pp'])) {

--- a/modules/content-overview/content-overview.php
+++ b/modules/content-overview/content-overview.php
@@ -813,7 +813,7 @@ class PP_Content_Overview extends PP_Module
         }
 
         // add taxononomies
-        $taxonomies = $this->get_all_taxonomies();
+        $taxonomies = $this->get_post_types_taxonomies($this->get_selected_post_types());
         $all_taxonomies = [];
         foreach ($taxonomies as $taxonomy) {
             if (in_array($taxonomy->name, ['post_status', 'post_status_core_wp_pp', 'post_visibility_pp'])) {


### PR DESCRIPTION
Show only Taxonomies attached to selected Post Types in Filter fix #1803