### PR TITLE
fix/#1905-Make-PP_Async_Notifications-send_notification-fail-more-gracefully-if-its-called-with-no-args 

### DIFF
--- a/modules/async-notifications/async-notifications.php
+++ b/modules/async-notifications/async-notifications.php
@@ -129,12 +129,12 @@ if (! class_exists('PP_Async_Notifications')) {
         /**
          * @param array $params
          */
-        public function send_notification($params)
+        public function send_notification($params = [])
         {
-            if (!is_array($params)) {
+            if (empty($params) || ! is_array($params) || ! isset($params['workflow_id'])) {
                 return;
             }
-            
+
             // Work the notification
             $workflow = Workflow::load_by_id((int)$params['workflow_id']);
             $workflow->event_args = $params['event_args'];


### PR DESCRIPTION
Make PP_Async_Notifications::send_notification() fail more gracefully if it's called with no args. fix #1905