### PR TITLE
Fix codescanning alert Add permissions section to code-check github workflow

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -17,6 +17,8 @@ on:
         description: 'Enable "tmate" for debugging'
         required: false
         default: false
+permissions:
+  contents: read
 jobs:
   check:
     name: Check the code

--- a/.github/workflows/deploy-wp.org-assets-readme.yml
+++ b/.github/workflows/deploy-wp.org-assets-readme.yml
@@ -6,6 +6,8 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
 jobs:
   deploy-to-trunk:
     name: Deploy assets/readme to trunk

--- a/.github/workflows/deploy-wp.org.yml
+++ b/.github/workflows/deploy-wp.org.yml
@@ -11,7 +11,8 @@ on:
         required: false
         default: false
 permissions:
-  contents: read
+  contents: write
+  packages: read
 jobs:
   code-check:
     name: Check the code

--- a/.github/workflows/deploy-wp.org.yml
+++ b/.github/workflows/deploy-wp.org.yml
@@ -10,7 +10,8 @@ on:
         description: 'Enable "tmate" for debugging'
         required: false
         default: false
-
+permissions:
+  contents: read
 jobs:
   code-check:
     name: Check the code


### PR DESCRIPTION
Fixes
- https://github.com/publishpress/publishpress-planner/security/code-scanning/45
- https://github.com/publishpress/publishpress-planner/security/code-scanning/44
- https://github.com/publishpress/publishpress-planner/security/code-scanning/43
- https://github.com/publishpress/publishpress-planner/security/code-scanning/42