### PR TITLE
Add labels to Planner form controls

### DIFF
--- a/modules/calendar/library/calendar-utilities.php
+++ b/modules/calendar/library/calendar-utilities.php
@@ -482,7 +482,7 @@ if (! class_exists('PP_Calendar_Utilities')) {
                 <div class="right-items">
                     <div class="item">
                         <div class="search-bar">
-                            <input type="search" id="co-searchbox-search-input" name="s" value="<?php _admin_search_query(); ?>" placeholder="<?php esc_attr_e('Search box', 'publishpress'); ?>" />
+                            <input type="search" id="co-searchbox-search-input" name="s" value="<?php _admin_search_query(); ?>" placeholder="<?php esc_attr_e('Search box', 'publishpress'); ?>" aria-label="<?php esc_attr_e('Search content', 'publishpress'); ?>" />
                             <?php submit_button(esc_html__('Search', 'publishpress'), '', '', false, ['id' => 'co-searchbox-search-submit']); ?>
                         </div>
                     </div>

--- a/modules/content-board/library/content-board-utilities.php
+++ b/modules/content-board/library/content-board-utilities.php
@@ -59,9 +59,9 @@ if (! class_exists('PP_Content_Board_Utilities')) {
                             <span class="close">&times;</span>
                             <div>
                                 <div class="metadata-item-filter custom-filter">
-                                    <div class="filter-title">
+                                    <label class="filter-title" for="pp_posts_per_page">
                                         <?php esc_html_e('Maximum number of posts to display', 'publishpress'); ?>
-                                    </div>
+                                    </label>
                                     <div class="filter-content">
                                         <form method="POST">
                                             <input type="hidden" name="co_form_action" value="settings_form"/>
@@ -94,7 +94,7 @@ if (! class_exists('PP_Content_Board_Utilities')) {
                     <?php endif; ?>
                     <div class="item">
                         <div class="search-bar">
-                            <input type="search" id="co-searchbox-search-input" name="s" value="<?php _admin_search_query(); ?>" placeholder="<?php esc_attr_e('Search box', 'publishpress'); ?>" />
+                            <input type="search" id="co-searchbox-search-input" name="s" value="<?php _admin_search_query(); ?>" placeholder="<?php esc_attr_e('Search box', 'publishpress'); ?>" aria-label="<?php esc_attr_e('Search content', 'publishpress'); ?>" />
                             <?php submit_button(esc_html__('Search', 'publishpress'), '', '', false, ['id' => 'co-searchbox-search-submit']); ?>
                         </div>
                     </div>

--- a/modules/content-overview/library/content-overview-methods.php
+++ b/modules/content-overview/library/content-overview-methods.php
@@ -284,9 +284,9 @@ if (! class_exists('PP_Overview_Methods')) {
                             <span class="close">&times;</span>
                             <div>
                                 <div class="metadata-item-filter custom-filter">
-                                    <div class="filter-title">
+                                    <label class="filter-title" for="pp_posts_per_page">
                                         <?php esc_html_e('Maximum number of posts to display', 'publishpress'); ?>
-                                    </div>
+                                    </label>
                                     <div class="filter-content">
                                         <form method="POST">
                                             <input type="hidden" name="co_form_action" value="settings_form"/>
@@ -319,7 +319,7 @@ if (! class_exists('PP_Overview_Methods')) {
                     <?php endif; ?>
                     <div class="item">
                         <div class="search-bar">
-                            <input type="search" id="co-searchbox-search-input" name="s" value="<?php _admin_search_query(); ?>" placeholder="<?php esc_attr_e('Search box', 'publishpress'); ?>" />
+                            <input type="search" id="co-searchbox-search-input" name="s" value="<?php _admin_search_query(); ?>" placeholder="<?php esc_attr_e('Search box', 'publishpress'); ?>" aria-label="<?php esc_attr_e('Search content', 'publishpress'); ?>" />
                             <?php submit_button(esc_html__('Search', 'publishpress'), '', '', false, ['id' => 'co-searchbox-search-submit']); ?>
                         </div>
                     </div>

--- a/modules/dashboard/widgets/dashboard-notepad.php
+++ b/modules/dashboard/widgets/dashboard-notepad.php
@@ -157,7 +157,8 @@ class PP_Dashboard_Notepad_Widget
             echo '<form id="dashboard-notepad">';
             echo '<input type="hidden" name="action" value="dashboard-notepad" />';
             echo '<input type="hidden" name="notepad-id" value="' . esc_attr($current_id) . '" />';
-            echo '<textarea style="width:100%" rows="10" name="note">';
+            echo '<label class="screen-reader-text" for="dashboard-notepad-note">' . esc_html__('Dashboard note', 'publishpress') . '</label>';
+            echo '<textarea id="dashboard-notepad-note" style="width:100%" rows="10" name="note">';
             echo esc_textarea(trim($current_note));
             echo '</textarea>';
             echo '<p class="submit">';
@@ -172,7 +173,8 @@ class PP_Dashboard_Notepad_Widget
             echo '</form>';
         } else {
             echo '<form id="dashboard-notepad">';
-            echo '<textarea style="width:100%" rows="10" name="note" disabled="disabled">';
+            echo '<label class="screen-reader-text" for="dashboard-notepad-note">' . esc_html__('Dashboard note', 'publishpress') . '</label>';
+            echo '<textarea id="dashboard-notepad-note" style="width:100%" rows="10" name="note" disabled="disabled">';
             echo esc_textarea(trim($current_note));
             echo '</textarea>';
             // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/modules/debug/views/view_log.html.php
+++ b/modules/debug/views/view_log.html.php
@@ -10,7 +10,8 @@
 
 <div id="upstream-debug-data">
     <h2><?php echo esc_html($context['label']['debug_data']); ?></h2>
-    <textarea readonly><?php echo $context['debug_data']; ?></textarea>
+    <label class="screen-reader-text" for="upstream-debug-data-textarea"><?php echo esc_html($context['label']['debug_data']); ?></label>
+    <textarea id="upstream-debug-data-textarea" readonly><?php echo $context['debug_data']; ?></textarea>
 </div>
 
 <hr>

--- a/modules/editorial-comments/library/EditorialCommentsTable.php
+++ b/modules/editorial-comments/library/EditorialCommentsTable.php
@@ -177,6 +177,7 @@ class EditorialCommentsTable extends WP_List_Table
 
             //post filter
             $post_id = isset($_GET['p']) ? (int)$_GET['p'] : 0;
+            echo '<label class="screen-reader-text" for="feditorial-comment-filter-posts">' . esc_html__('Filter by post', 'publishpress') . '</label>';
             echo '<select class="editorial-comment-filter-posts" id="feditorial-comment-filter-posts" name="p">';
             printf("\t<option value=''>%s</option>", __('All Posts', 'publishpress'));
             if (!empty($post_id)) {
@@ -192,6 +193,7 @@ class EditorialCommentsTable extends WP_List_Table
 
             //users filter
             $user_id = isset($_GET['user_id']) ? (int)$_GET['user_id'] : 0;
+            echo '<label class="screen-reader-text" for="feditorial-comment-filter-users">' . esc_html__('Filter by user', 'publishpress') . '</label>';
             echo '<select class="editorial-comment-filter-users" id="feditorial-comment-filter-users" name="user_id">';
             printf("\t<option value=''>%s</option>", __('All Users', 'publishpress'));
             if (!empty($user_id)) {

--- a/modules/notifications-log/library/NotificationsLogTable.php
+++ b/modules/notifications-log/library/NotificationsLogTable.php
@@ -563,7 +563,8 @@ class NotificationsLogTable extends WP_List_Table
         }
 
         // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-        echo '<select class="filter-posts" name="post_id">' . $selectedOptionEscaped . '</select>';
+        echo '<label class="screen-reader-text" for="publishpress-notifications-filter-posts">' . esc_html__('Filter by post', 'publishpress') . '</label>';
+        echo '<select class="filter-posts" id="publishpress-notifications-filter-posts" name="post_id">' . $selectedOptionEscaped . '</select>';
         // phpcs:enable
 
         // Workflow
@@ -578,13 +579,15 @@ class NotificationsLogTable extends WP_List_Table
         }
 
         // phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-        echo '<select class="filter-workflows" name="workflow_id">' . $selectedOptionEscaped . '</select>';
+        echo '<label class="screen-reader-text" for="publishpress-notifications-filter-workflows">' . esc_html__('Filter by workflow', 'publishpress') . '</label>';
+        echo '<select class="filter-workflows" id="publishpress-notifications-filter-workflows" name="workflow_id">' . $selectedOptionEscaped . '</select>';
         // phpcs:enable
 
         // Event
         $selectedAction = isset($_GET['event']) ? sanitize_text_field($_GET['event']) : '';
 
-        echo '<select class="filter-actions" name="event">';
+        echo '<label class="screen-reader-text" for="publishpress-notifications-filter-events">' . esc_html__('Filter by event', 'publishpress') . '</label>';
+        echo '<select class="filter-actions" id="publishpress-notifications-filter-events" name="event">';
         $events = apply_filters('publishpress_notifications_workflow_events', []);
 
         echo '<option value="">' . esc_html__('All events', 'publishpress') . '</option>';
@@ -601,7 +604,8 @@ class NotificationsLogTable extends WP_List_Table
         // Channel
         $selectedChannel = isset($_GET['channel']) ? sanitize_text_field($_GET['channel']) : '';
 
-        echo '<select class="filter-channels" name="channel">';
+        echo '<label class="screen-reader-text" for="publishpress-notifications-filter-channels">' . esc_html__('Filter by channel', 'publishpress') . '</label>';
+        echo '<select class="filter-channels" id="publishpress-notifications-filter-channels" name="channel">';
         $channels = apply_filters('psppno_filter_channels', []);
 
         echo '<option value="">' . esc_html__('All channels', 'publishpress') . '</option>';
@@ -621,13 +625,15 @@ class NotificationsLogTable extends WP_List_Table
 
         echo '<div class="filter-2nd-line">';
         echo '<span class="filter-dates">';
-        echo '<input type="text" class="filter-date-begin" name="date_begin" value="' . esc_attr(
+        echo '<label class="screen-reader-text" for="publishpress-notifications-filter-date-begin">' . esc_html__('From date', 'publishpress') . '</label>';
+        echo '<input type="text" class="filter-date-begin" id="publishpress-notifications-filter-date-begin" name="date_begin" value="' . esc_attr(
                 $dateBegin
             ) . '" placeholder="' . esc_html__(
                 'From date',
                 'publishpress'
             ) . '" />&nbsp;';
-        echo '&nbsp;<input type="text" class="filter-date-end" name="date_end" value="' . esc_attr(
+        echo '&nbsp;<label class="screen-reader-text" for="publishpress-notifications-filter-date-end">' . esc_html__('To date', 'publishpress') . '</label>';
+        echo '&nbsp;<input type="text" class="filter-date-end" id="publishpress-notifications-filter-date-end" name="date_end" value="' . esc_attr(
                 $dateEnd
             ) . '" placeholder="' . esc_html__(
                 'To date',
@@ -637,7 +643,8 @@ class NotificationsLogTable extends WP_List_Table
 
         // Receiver
         $receiver = isset($_GET['receiver']) ? sanitize_text_field($_GET['receiver']) : '';
-        echo '<input type="text" placeholder="' . esc_html__(
+        echo '<label class="screen-reader-text" for="publishpress-notifications-filter-receiver">' . esc_html__('Filter by receiver', 'publishpress') . '</label>';
+        echo '<input type="text" id="publishpress-notifications-filter-receiver" placeholder="' . esc_html__(
                 'All Receivers',
                 'publishpress'
             ) . '" name="receiver" value="' . esc_attr($receiver) . '" />';

--- a/modules/settings/views/footer-base.html.php
+++ b/modules/settings/views/footer-base.html.php
@@ -32,7 +32,7 @@ $rating_stars_markup = "
     </nav>
     <div class="pp-pressshack-logo">
         <a href="//publishpress.com" target="_blank" rel="noopener noreferrer">
-            <img src="<?php echo esc_url($context['plugin_url']); ?>common/img/publishpress-logo.png">
+            <img src="<?php echo esc_url($context['plugin_url']); ?>common/img/publishpress-logo.png" alt="<?php echo esc_attr($context['plugin_name']); ?>">
         </a>
     </div>
 </footer>

--- a/views/settings_notification_channels.html.php
+++ b/views/settings_notification_channels.html.php
@@ -20,7 +20,7 @@
                         <?php checked( $channel->name, $context['selected_channels'][$workflow->ID]); ?> />
 
                     <label for="psppno_workflow_channel_<?php echo esc_attr($workflow->ID); ?>_<?php echo esc_attr($channel->name); ?>">
-                        <img src="<?php echo esc_url($channel->icon); ?>"/>
+                        <img src="<?php echo esc_url($channel->icon); ?>" alt=""/>
                         <span><?php echo esc_html($channel->name); ?></span>
                     </label>
                 </div>

--- a/views/user_profile_notification_channels.html.php
+++ b/views/user_profile_notification_channels.html.php
@@ -40,7 +40,7 @@
                                             <?php checked( $channel->name, $context['workflow_channels'][$workflow->ID]); ?> />
 
                                     <label for="psppno_workflow_channel_<?php echo esc_attr($workflow->ID); ?>_<?php echo esc_attr($channel->name); ?>">
-                                        <img src="<?php echo esc_url($channel->icon); ?>"/>
+                                        <img src="<?php echo esc_url($channel->icon); ?>" alt=""/>
                                         <span><?php echo esc_html($channel->label); ?></span>
                                     </label>
                                 </div>

--- a/views/workflow_content_main_field.html.php
+++ b/views/workflow_content_main_field.html.php
@@ -9,7 +9,7 @@
     </div>
 
     <div>
-        <label><?php echo esc_html($context['labels']['body']); ?></label>
+        <label for="<?php echo esc_attr($context['input_id']); ?>"><?php echo esc_html($context['labels']['body']); ?></label>
         <?php wp_editor($context['body'], $context['input_id'], ['textarea_name' => $context['input_name'] . '[body]']); ?>
     </div>
 </div>

--- a/views/workflow_filter_multiple_select.html.php
+++ b/views/workflow_filter_multiple_select.html.php
@@ -1,4 +1,7 @@
 <?php if (! empty($context['options'])) : ?>
+    <?php if (! empty($context['labels']['label'])) : ?>
+        <label class="screen-reader-text" for="<?php echo esc_attr($context['id']); ?>"><?php echo esc_html($context['labels']['label']); ?></label>
+    <?php endif; ?>
     <select multiple="multiple" class="<?php echo isset($context['list_class']) ? esc_attr($context['list_class']) : ''; ?>" name="<?php echo esc_attr($context['name']); ?>[]" id="<?php echo esc_attr($context['id']); ?>">
         <?php foreach ($context['options'] as $option) : ?>
             <option value="<?php echo esc_attr($option['value']); ?>"

--- a/views/workflow_receiver_group_field.html.php
+++ b/views/workflow_receiver_group_field.html.php
@@ -7,6 +7,7 @@
             class="<?php echo esc_attr($context['id']); ?>_filters publishpress-filter-checkbox-list">
 
         <?php if (! empty($context['groups'])) : ?>
+            <label class="screen-reader-text" for="<?php echo esc_attr($context['input_id']); ?>"><?php printf(esc_html__('Select %s', 'publishpress'), esc_html($context['label'])); ?></label>
             <select multiple="multiple" class="<?php echo esc_attr($context['list_class']); ?>"
                     name="<?php echo esc_attr($context['input_name']); ?>" id="<?php echo esc_attr($context['input_id']); ?>">
                 <?php foreach ($context['groups'] as $group => $group_object) : ?>

--- a/views/workflow_receiver_role_field.html.php
+++ b/views/workflow_receiver_role_field.html.php
@@ -6,6 +6,7 @@
         class="<?php echo esc_attr($context['id']); ?>_filters publishpress-filter-checkbox-list">
 
     <?php if (! empty($context['roles'])) : ?>
+        <label class="screen-reader-text" for="<?php echo esc_attr($context['input_id']); ?>"><?php printf(esc_html__('Select %s', 'publishpress'), esc_html($context['label'])); ?></label>
         <select multiple="multiple" class="<?php echo esc_attr($context['list_class']); ?>"
                 name="<?php echo esc_attr($context['input_name']); ?>" id="<?php echo esc_attr($context['input_id']); ?>">
             <?php foreach ($context['roles'] as $role => $role_object) : ?>

--- a/views/workflow_receiver_user_field.html.php
+++ b/views/workflow_receiver_user_field.html.php
@@ -6,6 +6,7 @@
         class="<?php echo esc_attr($context['id']); ?>_filters publishpress-filter-checkbox-list">
 
     <?php if (! empty($context['users'])) : ?>
+        <label class="screen-reader-text" for="<?php echo esc_attr($context['input_id']); ?>"><?php printf(esc_html__('Select %s', 'publishpress'), esc_html($context['label'])); ?></label>
         <select multiple="multiple" class="<?php echo esc_attr($context['list_class']); ?>" name="<?php echo esc_attr($context['input_name']); ?>" id="<?php echo esc_attr($context['input_id']); ?>">
             <?php foreach ($context['users'] as $user) : ?>
                 <?php $selected = isset($user->selected) ? $user->selected : false; ?>


### PR DESCRIPTION
## Summary
- associate labels with dashboard note, debug, editorial comment, and notification log controls
- label workflow filter and receiver multi-selects and the notification editor body
- add accessible names to content search controls and image alt attributes

## Validation
- PHP lint for all changed PHP files
- `git diff --check`

This is an accessibility follow-up to the audit and complements #2032.