### PR TITLE
Improve semantic table markup in Planner

### DIFF
--- a/modules/content-board/library/content-board-utilities.php
+++ b/modules/content-board/library/content-board-utilities.php
@@ -994,7 +994,7 @@ if (! class_exists('PP_Content_Board_Utilities')) {
                             <tbody>
                                 <?php foreach ($post_fields as $field_key => $field_options) : ?>
                                     <tr>
-                                        <th>
+                                        <th scope="row">
                                             <label for="publishpress-content-board-field-<?php echo esc_attr($field_key); ?>">
                                                 <?php echo esc_html($field_options['label']); ?>
                                                 <?php if (!empty($field_options['required'])) : ?>

--- a/modules/content-overview/library/content-overview-utilities.php
+++ b/modules/content-overview/library/content-overview-utilities.php
@@ -321,7 +321,7 @@ if (! class_exists('PP_Content_Overview_Utilities')) {
                             <tbody>
                                 <?php foreach ($post_fields as $field_key => $field_options) : ?>
                                     <tr>
-                                        <th>
+                                        <th scope="row">
                                             <label for="publishpress-content-overview-field-<?php echo esc_attr($field_key); ?>">
                                                 <?php echo esc_html($field_options['label']); ?>
                                                 <?php if (!empty($field_options['required'])) : ?>

--- a/modules/debug/views/view_log.html.php
+++ b/modules/debug/views/view_log.html.php
@@ -22,18 +22,20 @@
         
         <h3><?php echo esc_html($context['label']['file_info']); ?></h3>
         <table id="upstream-debug-log-info">
+            <tbody>
             <tr>
-                <th><?php echo esc_html($context['label']['path']); ?>:</th>
+                <th scope="row"><?php echo esc_html($context['label']['path']); ?>:</th>
                 <td><?php echo esc_html($context['file']['path']); ?></td>
             </tr>
             <tr>
-                <th><?php echo esc_html($context['label']['size']); ?>:</th>
+                <th scope="row"><?php echo esc_html($context['label']['size']); ?>:</th>
                 <td><?php echo esc_html($context['file']['size']); ?> KB</td>
             </tr>
             <tr>
-                <th><?php echo esc_html($context['label']['modification_time']); ?>:</th>
+                <th scope="row"><?php echo esc_html($context['label']['modification_time']); ?>:</th>
                 <td><?php echo esc_html($context['file']['modification_time']); ?></td>
             </tr>
+            </tbody>
         </table>
 
         <p><?php echo esc_html($context['message']['click_to_delete']); ?></p>

--- a/views/settings_notification_channels.html.php
+++ b/views/settings_notification_channels.html.php
@@ -1,8 +1,8 @@
 <table class="psppno_workflow_user_fields psppno_workflows">
     <tr>
-        <th class="psppno_workflow_column_header psppno_workflows"><?php echo esc_html($context['labels']['workflows']); ?></th>
-        <th class="psppno_workflow_column_header psppno_channels"><?php echo esc_html($context['labels']['channels']); ?></th>
-        <th class="psppno_workflow_column_header psppno_options"></th>
+        <th scope="col" class="psppno_workflow_column_header psppno_workflows"><?php echo esc_html($context['labels']['workflows']); ?></th>
+        <th scope="col" class="psppno_workflow_column_header psppno_channels"><?php echo esc_html($context['labels']['channels']); ?></th>
+        <th scope="col" class="psppno_workflow_column_header psppno_options"><span class="screen-reader-text"><?php esc_html_e('Options', 'publishpress'); ?></span></th>
     </tr>
 
     <?php foreach ($context['workflows'] as $workflow) : ?>

--- a/views/user_profile_notification_channels.html.php
+++ b/views/user_profile_notification_channels.html.php
@@ -2,7 +2,7 @@
 
 <table class="form-table psppno_workflow_user_fields">
     <tr>
-        <th>
+        <th scope="row">
             <?php echo esc_html__(
                     'Choose the channels where each workflow will send notifications to:',
                     'publishpress');
@@ -11,9 +11,9 @@
         <td>
             <table class="psppno_workflows">
                 <tr>
-                    <th class="psppno_workflow_column_header psppno_workflows"><?php echo esc_html__('Workflows', 'publishpress'); ?></th>
-                    <th class="psppno_workflow_column_header psppno_channels"><?php echo esc_html__('Channels', 'publishpress'); ?></th>
-                    <th class="psppno_workflow_column_header psppno_options"></th>
+                    <th scope="col" class="psppno_workflow_column_header psppno_workflows"><?php echo esc_html__('Workflows', 'publishpress'); ?></th>
+                    <th scope="col" class="psppno_workflow_column_header psppno_channels"><?php echo esc_html__('Channels', 'publishpress'); ?></th>
+                    <th scope="col" class="psppno_workflow_column_header psppno_options"><span class="screen-reader-text"><?php esc_html_e('Options', 'publishpress'); ?></span></th>
                 </tr>
                 <?php 
                 foreach ($context['channels'] as $channel) {                    


### PR DESCRIPTION
## Summary
- add row scopes and explicit table-body markup to debug metadata
- add column scopes and an accessible options heading to notification channel tables
- mark Content Board and Content Overview form labels as row headers

## Validation
- PHP lint for all changed PHP files
- `git diff --check`

This is an accessibility follow-up to #2032 and #2033.