### PR TITLE
Add missing image alt attributes

### DIFF
--- a/modules/settings/views/footer-base.html.php
+++ b/modules/settings/views/footer-base.html.php
@@ -32,7 +32,7 @@ $rating_stars_markup = "
     </nav>
     <div class="pp-pressshack-logo">
         <a href="//publishpress.com" target="_blank" rel="noopener noreferrer">
-            <img src="<?php echo esc_url($context['plugin_url']); ?>common/img/publishpress-logo.png">
+            <img src="<?php echo esc_url($context['plugin_url']); ?>common/img/publishpress-logo.png" alt="<?php esc_attr_e('PublishPress', 'publishpress'); ?>">
         </a>
     </div>
 </footer>

--- a/views/settings_notification_channels.html.php
+++ b/views/settings_notification_channels.html.php
@@ -20,7 +20,7 @@
                         <?php checked( $channel->name, $context['selected_channels'][$workflow->ID]); ?> />
 
                     <label for="psppno_workflow_channel_<?php echo esc_attr($workflow->ID); ?>_<?php echo esc_attr($channel->name); ?>">
-                        <img src="<?php echo esc_url($channel->icon); ?>"/>
+                        <img src="<?php echo esc_url($channel->icon); ?>" alt=""/>
                         <span><?php echo esc_html($channel->name); ?></span>
                     </label>
                 </div>

--- a/views/user_profile_notification_channels.html.php
+++ b/views/user_profile_notification_channels.html.php
@@ -40,7 +40,7 @@
                                             <?php checked( $channel->name, $context['workflow_channels'][$workflow->ID]); ?> />
 
                                     <label for="psppno_workflow_channel_<?php echo esc_attr($workflow->ID); ?>_<?php echo esc_attr($channel->name); ?>">
-                                        <img src="<?php echo esc_url($channel->icon); ?>"/>
+                                        <img src="<?php echo esc_url($channel->icon); ?>" alt=""/>
                                         <span><?php echo esc_html($channel->label); ?></span>
                                     </label>
                                 </div>


### PR DESCRIPTION
## Summary
- add accessible alt text to the PublishPress footer logo
- mark notification channel icons as decorative with empty alt attributes

## Validation
- php -l on all changed PHP templates
- git diff --check