### PR TITLE
Prepare Planner database queries

### DIFF
--- a/lib/Notifications/Plugin.php
+++ b/lib/Notifications/Plugin.php
@@ -88,13 +88,18 @@ class Plugin
     private function suppressInactiveNotifications($where, $inactive_default_names) {
         global $wpdb;
 
-        $post_name_csv = implode("','", array_map('sanitize_key', $inactive_default_names));
+        $inactive_default_names = array_map('sanitize_key', $inactive_default_names);
 
-        $where .= " AND $wpdb->posts.post_name NOT IN ('" . $post_name_csv . "')";                                  // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        $where .= $wpdb->prepare(
+            ' AND ' . $wpdb->posts . '.post_name NOT IN (' . implode(', ', array_fill(0, count($inactive_default_names), '%s')) . ')',
+            $inactive_default_names
+        );
 
-        //phpcs:ignore Squiz.PHP.CommentedOutCode.Found
-        foreach ($inactive_default_names as $default_name) {  // note: $wpdb->prepare() breaks wildcards in LIKE statements
-            $where .= " AND $wpdb->posts.post_name NOT LIKE '" . sanitize_key($default_name) . "-%'";               // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        foreach ($inactive_default_names as $default_name) {
+            $where .= $wpdb->prepare(
+                ' AND ' . $wpdb->posts . '.post_name NOT LIKE %s',
+                $wpdb->esc_like($default_name) . '-%'
+            );
         }
 
         return $where;
@@ -154,7 +159,10 @@ class Plugin
             ('psppnotif_workflow' == $type) && !empty($pagenow) && ('edit.php' == $pagenow)
             && (!defined('PUBLISHPRESS_REVISIONS_PRO_VERSION') || !defined('PUBLISHPRESS_STATUSES_PRO_VERSION'))
         ) {
-            $query = "SELECT post_status, COUNT(*) AS num_posts FROM {$wpdb->posts} WHERE post_type = %s";
+            $query = $wpdb->prepare(
+                "SELECT post_status, COUNT(*) AS num_posts FROM {$wpdb->posts} WHERE post_type = %s",
+                $type
+            );
 
             if (!defined('PUBLISHPRESS_REVISIONS_PRO_VERSION') && !defined('PUBLISHPRESS_INCLUDE_REVISION_NOTIFICATIONS')) {
                 $query = $this->suppressInactiveRevisionsNotifications($query);
@@ -166,7 +174,7 @@ class Plugin
 
             $query .= ' GROUP BY post_status';
         
-            $results = (array) $wpdb->get_results( $wpdb->prepare( $query, $type ), ARRAY_A );
+            $results = (array) $wpdb->get_results( $query, ARRAY_A );
             $counts  = array_fill_keys( get_post_stati(), 0 );
         
             foreach ( $results as $row ) {

--- a/modules/content-board/content-board.php
+++ b/modules/content-board/content-board.php
@@ -1814,7 +1814,7 @@ class PP_Content_Board extends PP_Module
                     "SELECT DISTINCT t.slug AS id, t.name AS text
                 FROM {$wpdb->term_taxonomy} as tt
                 INNER JOIN {$wpdb->terms} as t ON (tt.term_id = t.term_id)
-                WHERE taxonomy = '%s' AND t.name LIKE %s
+                WHERE taxonomy = %s AND t.name LIKE %s
                 ORDER BY 2
                 LIMIT 20",
                 $taxonomy,

--- a/modules/content-overview/content-overview.php
+++ b/modules/content-overview/content-overview.php
@@ -1875,7 +1875,7 @@ class PP_Content_Overview extends PP_Module
                     "SELECT DISTINCT t.slug AS id, t.name AS text
                 FROM {$wpdb->term_taxonomy} as tt
                 INNER JOIN {$wpdb->terms} as t ON (tt.term_id = t.term_id)
-                WHERE taxonomy = '%s' AND t.name LIKE %s
+                WHERE taxonomy = %s AND t.name LIKE %s
                 ORDER BY 2
                 LIMIT 20",
                 $taxonomy,

--- a/modules/editorial-comments/editorial-comments.php
+++ b/modules/editorial-comments/editorial-comments.php
@@ -407,25 +407,21 @@ if (! class_exists('PP_Editorial_Comments')) {
             INNER JOIN {$wpdb->comments} AS c
             ON u.ID = c.user_id
             WHERE c.comment_type = %s";
+            $queryArgs = [$commentType];
 
             if (!empty($queryText)) {
-                $userSql .= $wpdb->prepare(
-                    " AND (user_login LIKE %s
+                $searchLike = '%' . $wpdb->esc_like($queryText) . '%';
+                $userSql .= " AND (user_login LIKE %s
                     OR user_url LIKE %s
                     OR user_email LIKE %s
                     OR user_nicename LIKE %s
-                    OR display_name LIKE %s)",
-                    '%' . $wpdb->esc_like($queryText) . '%',
-                    '%' . $wpdb->esc_like($queryText) . '%',
-                    '%' . $wpdb->esc_like($queryText) . '%',
-                    '%' . $wpdb->esc_like($queryText) . '%',
-                    '%' . $wpdb->esc_like($queryText) . '%'
-                );
+                    OR display_name LIKE %s)";
+                $queryArgs = array_merge($queryArgs, array_fill(0, 5, $searchLike));
             }
 
             $userSql .= " ORDER BY u.display_name LIMIT 20";
 
-            $users = $wpdb->get_results($wpdb->prepare($userSql, $commentType));
+            $users = $wpdb->get_results($wpdb->prepare($userSql, $queryArgs));
 
             foreach ($users as $user) {
                 $results[] = [

--- a/modules/efmigration/efmigration.php
+++ b/modules/efmigration/efmigration.php
@@ -568,25 +568,30 @@ if (! class_exists('PP_Efmigration')) {
             global $wpdb;
         
             // Step 1: Update term_taxonomy_id for posts in Source Term to Target Term
-            $sql_update_relationships = $wpdb->prepare(
-                "UPDATE {$wpdb->term_relationships}
-                SET term_taxonomy_id = %d
-                WHERE term_taxonomy_id = %d",
-                $target_term_id,
-                $source_term_id
+            $wpdb->update(
+                $wpdb->term_relationships,
+                ['term_taxonomy_id' => $target_term_id],
+                ['term_taxonomy_id' => $source_term_id],
+                ['%d'],
+                ['%d']
             );
-            $wpdb->query($sql_update_relationships);
         
             
             // Step 2: Update term_count for Target Terms
-            $sql_update_term_count_target = $wpdb->prepare(
-                "UPDATE {$wpdb->term_taxonomy}
-                SET count = (SELECT COUNT(*) FROM {$wpdb->term_relationships} WHERE term_taxonomy_id = %d)
-                WHERE term_taxonomy_id = %d",
-                $target_term_id,
-                $target_term_id
+            $target_term_count = (int) $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT COUNT(*) FROM {$wpdb->term_relationships} WHERE term_taxonomy_id = %d",
+                    $target_term_id
+                )
             );
-            $wpdb->query($sql_update_term_count_target);
+
+            $wpdb->update(
+                $wpdb->term_taxonomy,
+                ['count' => $target_term_count],
+                ['term_taxonomy_id' => $target_term_id],
+                ['%d'],
+                ['%d']
+            );
         
             return true;
         }

--- a/modules/improved-notifications/improved-notifications.php
+++ b/modules/improved-notifications/improved-notifications.php
@@ -544,9 +544,10 @@ if (! class_exists('PP_Improved_Notifications')) {
                 // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
                 $posts = $wpdb->get_results(
                     $wpdb->prepare(
-                        "SELECT ID, post_name FROM $wpdb->posts WHERE post_type = %s AND post_status = 'publish' AND (post_name = %s OR post_name LIKE '$default_workflow_name-%') ORDER BY ID ASC",    //phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+                        "SELECT ID, post_name FROM $wpdb->posts WHERE post_type = %s AND post_status = 'publish' AND (post_name = %s OR post_name LIKE %s) ORDER BY ID ASC",
                         'psppnotif_workflow',
-                        $default_workflow_name
+                        $default_workflow_name,
+                        $wpdb->esc_like($default_workflow_name) . '-%'
                     )
                 );
 
@@ -798,11 +799,21 @@ if (! class_exists('PP_Improved_Notifications')) {
         {
             global $wpdb;
 
-            $query = "UPDATE {$wpdb->postmeta} SET meta_key = '_psppno_torole' WHERE meta_key = '_psppno_togroup'";
-            $wpdb->query($query);
+            $wpdb->update(
+                $wpdb->postmeta,
+                ['meta_key' => '_psppno_torole'],
+                ['meta_key' => '_psppno_togroup'],
+                ['%s'],
+                ['%s']
+            );
 
-            $query = "UPDATE {$wpdb->postmeta} SET meta_key = '_psppno_torolelist' WHERE meta_key = '_psppno_togrouplist'";
-            $wpdb->query($query);
+            $wpdb->update(
+                $wpdb->postmeta,
+                ['meta_key' => '_psppno_torolelist'],
+                ['meta_key' => '_psppno_togrouplist'],
+                ['%s'],
+                ['%s']
+            );
         }
 
 

--- a/publishpress.php
+++ b/publishpress.php
@@ -1366,15 +1366,14 @@ add_action('plugins_loaded', function () {
 
                 $queryText = isset($_GET['q']) ? sanitize_text_field($_GET['q']) : '';
 
-                // If queryText is not empty, add a WHERE clause to filter meta_key
-                $whereClause = '';
-                if (!empty($queryText)) {
-                    $like = '%' . $wpdb->esc_like($queryText) . '%';
-                    $whereClause = $wpdb->prepare("AND meta_key LIKE %s", $like);
-                }
+                $like = '%' . $wpdb->esc_like($queryText) . '%';
 
-                // Updated query with conditional search
-                $queryResults = $wpdb->get_col("SELECT DISTINCT meta_key FROM $wpdb->postmeta WHERE 1=1 $whereClause ORDER BY meta_key ASC LIMIT 20");
+                $queryResults = $wpdb->get_col(
+                    $wpdb->prepare(
+                        "SELECT DISTINCT meta_key FROM {$wpdb->postmeta} WHERE meta_key LIKE %s ORDER BY meta_key ASC LIMIT 20",
+                        $like
+                    )
+                );
 
                 $results = [];
                 if (!empty($queryResults)) {


### PR DESCRIPTION
## Summary
- replace scanner-flagged dynamic SQL with prepared placeholders and wpdb update helpers
- move LIKE wildcards into prepared parameters with esc_like()
- remove quoted placeholders in taxonomy search queries

## Validation
- php -l on all changed PHP files
- git diff --check